### PR TITLE
case sensitive name

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -137,7 +137,7 @@ imports:
   version: 1d7be4effb13d2d908342d349d71a284a7542693
   subpackages:
   - zk
-- name: github.com/Sirupsen/logrus
+- name: github.com/sirupsen/logrus
   version: ba1b36c82c5e05c4f912a88eab0dcd91a171688f
 - name: github.com/ugorji/go
   version: ded73eae5db7e7a0ef6f55aace87a2873c5d2b74

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
     log "github.com/mgutz/logxi/v1"
-    "github.com/Sirupsen/logrus"
+    "github.com/sirupsen/logrus"
     "github.com/hashicorp/vault/physical"
     "github.com/urfave/cli"
     "os"
@@ -54,7 +54,7 @@ func moveData(path string, from physical.Backend, to physical.Backend) error {
             continue
         }
         err = to.Put(entry)
-        
+
         if err != nil {
             return err
         }
@@ -90,7 +90,7 @@ func main() {
         Usage: "config file",
         EnvVar: "VAULT_MIGRATOR_CONFIG_FILE",
     }}
-    
+
     app.Action = func(c *cli.Context) error {
         configFile := c.String("config")
         configRaw, err := ioutil.ReadFile(configFile)
@@ -136,9 +136,9 @@ func main() {
         for {
             time.Sleep(time.Second * 60)
             logrus.Info("Waiting the next schedule")
-    
+
         }
-        
+
     }
     err := app.Run(os.Args)
     if err != nil {


### PR DESCRIPTION
glide complains on case sensitive folder name

Example output

```
[INFO] ...
[ERROR]	Update failed for github.com/Sirupsen/logrus: The Remote does not match the VCS endpoint

```

Signed-off-by: Daniel Nilsson <daniel.nilsson1989@gmail.com>