### PR TITLE
Update to Vault 0.8.1

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,124 +1,25 @@
 hash: 4da94405db8c7f4eb48fa2e5f581e6c934deb46d402948283a2dfbe901642bb7
-updated: 2017-04-22T02:59:24.273268434-05:00
+updated: 2017-12-26T23:20:55.629388112-06:00
 imports:
-- name: cloud.google.com/go
-  version: 3b1ae45394a234c385be014e9a488f2bb6eef821
-  subpackages:
-  - compute/metadata
-  - internal
-  - storage
-- name: github.com/armon/go-metrics
-  version: 93f237eba9b0602f3e73710416558854a81d9337
-- name: github.com/armon/go-radix
-  version: 4239b77079c7b5d1243b7b4736304ce8ddb6f0f2
-- name: github.com/aws/aws-sdk-go
-  version: 695fe24acaf9afe80b0ce261d4637f42ba0b4c7d
-  subpackages:
-  - aws
-  - aws/awserr
-  - aws/awsutil
-  - aws/client
-  - aws/client/metadata
-  - aws/corehandlers
-  - aws/credentials
-  - aws/credentials/ec2rolecreds
-  - aws/credentials/endpointcreds
-  - aws/credentials/stscreds
-  - aws/defaults
-  - aws/ec2metadata
-  - aws/endpoints
-  - aws/request
-  - aws/session
-  - aws/signer/v4
-  - private/protocol
-  - private/protocol/json/jsonutil
-  - private/protocol/jsonrpc
-  - private/protocol/query
-  - private/protocol/query/queryutil
-  - private/protocol/rest
-  - private/protocol/restxml
-  - private/protocol/xml/xmlutil
-  - private/waiter
-  - service/dynamodb
-  - service/dynamodb/dynamodbattribute
-  - service/s3
-  - service/sts
-- name: github.com/Azure/azure-sdk-for-go
-  version: 4897648e310020dae650a89c31ff633284c13a24
-  subpackages:
-  - storage
-- name: github.com/coreos/etcd
-  version: fba87558a6fc26f2daaba4ceca1c5805af83fe0a
-  subpackages:
-  - auth/authpb
-  - client
-  - clientv3
-  - clientv3/concurrency
-  - etcdserver/api/v3rpc/rpctypes
-  - etcdserver/etcdserverpb
-  - mvcc/mvccpb
-  - pkg/pathutil
-  - pkg/tlsutil
-  - pkg/transport
-  - pkg/types
-  - version
-- name: github.com/coreos/go-semver
-  version: 568e959cd89871e61434c1143528d9162da89ef2
-  subpackages:
-  - semver
-- name: github.com/go-ini/ini
-  version: 98c45284d68a05a0e0a576de574bd975946ef9ad
-- name: github.com/go-sql-driver/mysql
-  version: 2e00b5cd70399450106cec6431c2e2ce3cae5034
 - name: github.com/golang/protobuf
   version: 4bd1920723d7b7c925de087aa32e2187708897f7
   subpackages:
-  - jsonpb
   - proto
-- name: github.com/grpc-ecosystem/grpc-gateway
-  version: 84398b94e188ee336f307779b57b3aa91af7063c
-  subpackages:
-  - runtime
-  - runtime/internal
-  - utilities
-- name: github.com/hashicorp/consul
-  version: 21f2d5ad0c02af6c4b32d8fd04f7c81e9b002d41
-  subpackages:
-  - api
-  - lib
 - name: github.com/hashicorp/errwrap
   version: 7554cd9344cec97297fa6649b055a8c98c2a1e55
-- name: github.com/hashicorp/go-cleanhttp
-  version: 3573b8b52aa7b37b9358d966a898feb387f62437
+- name: github.com/hashicorp/go-immutable-radix
+  version: 8aac2701530899b64bdea735a1de8da899815220
 - name: github.com/hashicorp/go-multierror
   version: ed905158d87462226a13fe39ddf685ea65f1c11f
-- name: github.com/hashicorp/go-uuid
-  version: 64130c7a86d732268a38cb04cfbaf0cc987fda98
 - name: github.com/hashicorp/golang-lru
   version: 0a025b7e63adc15a622f29b0b2c4c3848243bbf6
   subpackages:
   - simplelru
-- name: github.com/hashicorp/serf
-  version: 19f2c401e122352c047a84d6584dd51e2fb8fcc4
-  subpackages:
-  - coordinate
 - name: github.com/hashicorp/vault
-  version: 614deacfca3f3b7162bbf30a36d6fc7362cd47f0
+  version: 87b6919dea55da61d7cd444b2442cabb8ede8ab1
   subpackages:
-  - helper/awsutil
-  - helper/compressutil
-  - helper/consts
-  - helper/jsonutil
   - helper/locksutil
-  - helper/strutil
-  - helper/tlsutil
   - physical
-- name: github.com/jmespath/go-jmespath
-  version: bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
-- name: github.com/lib/pq
-  version: 472a0745531a17dbac346e828b4c60e73ddff30c
-  subpackages:
-  - oid
 - name: github.com/mattn/go-colorable
   version: a392f450ea64cee2b268dfaacdc2502b50a22b18
 - name: github.com/mattn/go-isatty
@@ -129,80 +30,14 @@ imports:
   version: aebf8a7d67ab4625e0fd4a665766fef9a709161b
   subpackages:
   - v1
-- name: github.com/ncw/swift
-  version: 8e9b10220613abdbc2896808ee6b43e411a4fa6c
 - name: github.com/robfig/cron
   version: b024fc5ea0e34bc3f83d9941c8d60b0622bfaca4
-- name: github.com/samuel/go-zookeeper
-  version: 1d7be4effb13d2d908342d349d71a284a7542693
-  subpackages:
-  - zk
 - name: github.com/sirupsen/logrus
   version: ba1b36c82c5e05c4f912a88eab0dcd91a171688f
-- name: github.com/ugorji/go
-  version: ded73eae5db7e7a0ef6f55aace87a2873c5d2b74
-  subpackages:
-  - codec
 - name: github.com/urfave/cli
   version: 0bdeddeeb0f650497d603c4ad7b20cfe685682f6
-- name: golang.org/x/net
-  version: f2499483f923065a842d38eb4c7f1927e6fc6e6d
-  subpackages:
-  - context
-  - context/ctxhttp
-  - http2
-  - http2/hpack
-  - idna
-  - internal/timeseries
-  - lex/httplex
-  - trace
-- name: golang.org/x/oauth2
-  version: 3c3a985cb79f52a3190fbc056984415ca6763d01
-  subpackages:
-  - google
-  - internal
-  - jws
-  - jwt
 - name: golang.org/x/sys
   version: 99f16d856c9836c42d24e7ab64ea72916925fa97
   subpackages:
   - unix
-- name: google.golang.org/api
-  version: cbeb0ff89adddeef6a3287fa481dcca2b596ed36
-  subpackages:
-  - gensupport
-  - googleapi
-  - googleapi/internal/uritemplates
-  - googleapi/transport
-  - internal
-  - iterator
-  - option
-  - storage/v1
-  - transport
-- name: google.golang.org/appengine
-  version: 4f7eeb5305a4ba1966344836ba4af9996b7b4e05
-  subpackages:
-  - internal
-  - internal/app_identity
-  - internal/base
-  - internal/datastore
-  - internal/log
-  - internal/modules
-  - internal/remote_api
-  - internal/socket
-  - internal/urlfetch
-  - socket
-  - urlfetch
-- name: google.golang.org/grpc
-  version: 777daa17ff9b5daef1cfdf915088a2ada3332bf0
-  subpackages:
-  - codes
-  - credentials
-  - credentials/oauth
-  - grpclog
-  - internal
-  - metadata
-  - naming
-  - peer
-  - transport
 testImports: []

--- a/main.go
+++ b/main.go
@@ -1,147 +1,176 @@
 package main
 
 import (
-    log "github.com/mgutz/logxi/v1"
-    "github.com/sirupsen/logrus"
-    "github.com/hashicorp/vault/physical"
-    "github.com/urfave/cli"
-    "os"
-    "io/ioutil"
-    "encoding/json"
-    "fmt"
-    "strings"
-    "github.com/robfig/cron"
-    "time"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+	"time"
+
+	vaultcli "github.com/hashicorp/vault/cli"
+	vaultcommand "github.com/hashicorp/vault/command"
+	"github.com/hashicorp/vault/physical"
+	log "github.com/mgutz/logxi/v1"
+	"github.com/robfig/cron"
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli"
 )
+
+var backendFactories map[string]physical.Factory
+
+func init() {
+	// fish the backend factories out of the vault CLI, since that is inexplicably where
+	// this map is assembled
+	vaultCommands := vaultcli.Commands(nil)
+	cmd, err := vaultCommands["server"]()
+	if err != nil {
+		logrus.Fatal("'vault server' init failed", err)
+	}
+	serverCommand, ok := cmd.(*vaultcommand.ServerCommand)
+	if !ok {
+		logrus.Fatal("'vault server' did not return a ServerCommand")
+	}
+	backendFactories = serverCommand.PhysicalBackends
+}
+
+func newBackend(kind string, logger log.Logger, conf map[string]string) (physical.Backend, error) {
+	if factory := backendFactories[kind]; factory == nil {
+		return nil, fmt.Errorf("no Vault backend is named %+q", kind)
+	} else {
+		return factory(conf, logger)
+	}
+}
 
 //Backend is a supported storage backend by vault
 type Backend struct {
-    //Use the same name that is used in the vault config file
-    Name   string `json:"name"`
-    //Put here the configuration of your picked backend
-    Config map[string]string `json:"config"`
+	//Use the same name that is used in the vault config file
+	Name string `json:"name"`
+	//Put here the configuration of your picked backend
+	Config map[string]string `json:"config"`
 }
 
 //Config config.json structure
 type Config struct {
-    //Source
-    From     *Backend `json:"from"`
-    //Destination
-    To       *Backend `json:"to"`
-    //Schedule (optional)
-    Schedule *string  `json:"schedule"`
+	//Source
+	From *Backend `json:"from"`
+	//Destination
+	To *Backend `json:"to"`
+	//Schedule (optional)
+	Schedule *string `json:"schedule"`
 }
 
 func moveData(path string, from physical.Backend, to physical.Backend) error {
-    keys, err := from.List(path)
-    if err != nil {
-        return err
-    }
-    for _, key := range keys {
-        logrus.Infoln("moving key: ", path + key)
-        if strings.HasSuffix(key, "/") {
-            err := moveData(path + key, from, to)
-            if err != nil {
-                return err
-            }
-            continue
-        }
-        entry, err := from.Get(path + key)
-        if err != nil {
-            return err
-        }
-        if entry == nil {
-            continue
-        }
-        err = to.Put(entry)
+	keys, err := from.List(path)
+	if err != nil {
+		return err
+	}
+	for _, key := range keys {
+		logrus.Infoln("moving key: ", path+key)
+		if strings.HasSuffix(key, "/") {
+			err := moveData(path+key, from, to)
+			if err != nil {
+				return err
+			}
+			continue
+		}
+		entry, err := from.Get(path + key)
+		if err != nil {
+			return err
+		}
+		if entry == nil {
+			continue
+		}
+		err = to.Put(entry)
 
-        if err != nil {
-            return err
-        }
-    }
-    if path == "" {
-        logrus.Info("all the keys have been moved ")
-    }
-    return nil
+		if err != nil {
+			return err
+		}
+	}
+	if path == "" {
+		logrus.Info("all the keys have been moved ")
+	}
+	return nil
 }
 
 func move(config *Config) error {
-    logger := log.New("vault-migrator")
-    from, err := physical.NewBackend(config.From.Name, logger, config.From.Config)
-    if err != nil {
-        return err
-    }
-    to, err := physical.NewBackend(config.To.Name, logger, config.To.Config)
-    if err != nil {
-        return err
-    }
-    return moveData("", from, to)
+	logger := log.New("vault-migrator")
+
+	from, err := newBackend(config.From.Name, logger, config.From.Config)
+	if err != nil {
+		return err
+	}
+	to, err := newBackend(config.To.Name, logger, config.To.Config)
+	if err != nil {
+		return err
+	}
+	return moveData("", from, to)
 }
 
 func main() {
-    app := cli.NewApp()
-    app.Name = "vault-migrator"
-    app.Usage = ""
-    app.Version = version
-    app.Authors = []cli.Author{{"nebtex", "publicdev@nebtex.com"}}
-    app.Flags = []cli.Flag{cli.StringFlag{
-        Name: "config, c",
-        Value: "",
-        Usage: "config file",
-        EnvVar: "VAULT_MIGRATOR_CONFIG_FILE",
-    }}
+	app := cli.NewApp()
+	app.Name = "vault-migrator"
+	app.Usage = ""
+	app.Version = version
+	app.Authors = []cli.Author{{"nebtex", "publicdev@nebtex.com"}}
+	app.Flags = []cli.Flag{cli.StringFlag{
+		Name:   "config, c",
+		Value:  "",
+		Usage:  "config file",
+		EnvVar: "VAULT_MIGRATOR_CONFIG_FILE",
+	}}
 
-    app.Action = func(c *cli.Context) error {
-        configFile := c.String("config")
-        configRaw, err := ioutil.ReadFile(configFile)
-        if err != nil {
-            return err
-        }
-        config := &Config{}
-        err = json.Unmarshal(configRaw, config)
-        if err != nil {
-            return err
-        }
-        if config.From == nil {
-            return fmt.Errorf("%v", "Please define a source (key: from)")
-        }
-        if config.To == nil {
-            return fmt.Errorf("%v", "Please define a destination (key: to)")
-        }
-        if config.Schedule == nil {
-            return move(config)
-        }
-        cr := cron.New()
-        err = cr.AddFunc(*config.Schedule, func() {
-            defer func() {
-                err := recover()
-                if err != nil {
-                    logrus.Errorln(err)
-                }
-            }()
-            err = move(config)
-            if err != nil {
-                logrus.Errorln(err)
-            }
-        })
-        if err != nil {
-            return err
-        }
-        cr.Start()
-        //make initial migration
-        err = move(config)
-        if err != nil {
-            return err
-        }
-        for {
-            time.Sleep(time.Second * 60)
-            logrus.Info("Waiting the next schedule")
+	app.Action = func(c *cli.Context) error {
+		configFile := c.String("config")
+		configRaw, err := ioutil.ReadFile(configFile)
+		if err != nil {
+			return err
+		}
+		config := &Config{}
+		err = json.Unmarshal(configRaw, config)
+		if err != nil {
+			return err
+		}
+		if config.From == nil {
+			return fmt.Errorf("%v", "Please define a source (key: from)")
+		}
+		if config.To == nil {
+			return fmt.Errorf("%v", "Please define a destination (key: to)")
+		}
+		if config.Schedule == nil {
+			return move(config)
+		}
+		cr := cron.New()
+		err = cr.AddFunc(*config.Schedule, func() {
+			defer func() {
+				err := recover()
+				if err != nil {
+					logrus.Errorln(err)
+				}
+			}()
+			err = move(config)
+			if err != nil {
+				logrus.Errorln(err)
+			}
+		})
+		if err != nil {
+			return err
+		}
+		cr.Start()
+		//make initial migration
+		err = move(config)
+		if err != nil {
+			return err
+		}
+		for {
+			time.Sleep(time.Second * 60)
+			logrus.Info("Waiting the next schedule")
 
-        }
+		}
 
-    }
-    err := app.Run(os.Args)
-    if err != nil {
-        logrus.Fatal(err)
-    }
+	}
+	err := app.Run(os.Args)
+	if err != nil {
+		logrus.Fatal(err)
+	}
 }


### PR DESCRIPTION
I wanted to use `vault-migrator` with `etcd` but ran into trouble using the prebuilt binaries. This changeset fixes it.

I updated `vault-migrator` to track upstream via `glide up github.com/hashicorp/vault`, which brings it to ~0.8.1. This updated all the backends but broke `vault-migrator` because the internal APIs changed. Somehow they refactored it such that the complete list of physical backends exists [only in `vault/cli/commands.go`](https://github.com/hashicorp/vault/blob/master/cli/commands.go#L130-L152), so this PR fishes it back out again in `func init()` and replaces `physical.NewBackend()` with a replacement `newBackend()`.

Also, I guess this PR `gofmt` + `goimport`s `main.go` because my editor does that on save.