### PR TITLE
Refactor using parallel workers for get/put operations

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -1,6 +1,6 @@
 package: github.com/nebtex/vault-migrate-dynamo-consul
 import:
 - package: github.com/hashicorp/vault
-  version: ^0.7.0
+  version: ^0.8.2
 - package: github.com/robfig/cron
   version: ^1.0.0

--- a/main.go
+++ b/main.go
@@ -90,6 +90,7 @@ func populateKeyQueue(path string, from physical.Backend, keyQueue chan string) 
 // Retrieve keys from the queue until the channel is closed
 func processKeyQueue(id int, from physical.Backend, to physical.Backend, keyQueue chan string, workerWaitGroup sync.WaitGroup) {
     logrus.Infoln("Worker ", id, " starting")
+    defer workerWaitGroup.Done()
     for {
         key, more := <-keyQueue
         if more {
@@ -99,7 +100,6 @@ func processKeyQueue(id int, from physical.Backend, to physical.Backend, keyQueu
         }
     }
     logrus.Infoln("Worker ", id, " done")
-    workerWaitGroup.Done()
 }
 
 func moveKey(key string, from physical.Backend, to physical.Backend) error {
@@ -183,8 +183,8 @@ func main() {
             config.QueueSize = 10000
         }
         if config.Workers <= 0 {
-            // Default workers to 10
-            config.Workers = 10
+            // Default workers to 1
+            config.Workers = 1
         }
 
         if config.Schedule == nil {

--- a/main.go
+++ b/main.go
@@ -183,8 +183,8 @@ func main() {
             config.QueueSize = 10000
         }
         if config.Workers <= 0 {
-            // Default workers to 100
-            config.Workers = 100
+            // Default workers to 10
+            config.Workers = 10
         }
 
         if config.Schedule == nil {

--- a/main.go
+++ b/main.go
@@ -63,7 +63,7 @@ type Config struct {
     QueueSize int `json:"queuesize"`
     //Number of Workers (optional)
     Workers int `json:"workers"`
-    //Debug logging (optional)
+    //Turn on debug logging (optional)
     Debug bool `json:"debug"`
 }
 
@@ -117,7 +117,7 @@ func moveKey(key string, from physical.Backend, to physical.Backend) error {
             return err
         }
     } else {
-        logrus.Infoln("key not found:", key)
+        logrus.Warnln("key not found:", key)
     }
 
     return nil
@@ -134,19 +134,19 @@ func move(config *Config) error {
     if err != nil {
         return err
     }
-    logrus.Infoln("Starting", config.Workers, "workers...")
+    logrus.Debugln("Starting", config.Workers, "workers...")
     var workerWaitGroup sync.WaitGroup
     workerWaitGroup.Add(config.Workers)
     for id := 1; id <= config.Workers; id++ {
         go processKeyQueue(id, from, to, keyQueue, &workerWaitGroup)
     }
-    logrus.Infoln("Starting to move keys...")
+    logrus.Infoln("Moving keys...")
     populateKeyQueue("", from, keyQueue)
-    logrus.Infoln("All keys added to queue...")
+    logrus.Debugln("All keys added to queue...")
     close(keyQueue)
-    logrus.Infoln("Waiting for workers to finish...")
+    logrus.Debugln("Waiting for workers to finish...")
     workerWaitGroup.Wait()
-    logrus.Infoln("All workers finished")
+    logrus.Infoln("all the keys have been moved")
     return nil
 }
 

--- a/main.go
+++ b/main.go
@@ -1,64 +1,64 @@
 package main
 
 import (
-	"encoding/json"
-	"fmt"
-	"io/ioutil"
-	"os"
-	"strings"
-	"time"
+    "encoding/json"
+    "fmt"
+    "io/ioutil"
+    "os"
+    "strings"
+    "time"
 
-	vaultcli "github.com/hashicorp/vault/cli"
-	vaultcommand "github.com/hashicorp/vault/command"
-	"github.com/hashicorp/vault/physical"
-	log "github.com/mgutz/logxi/v1"
-	"github.com/robfig/cron"
-	"github.com/sirupsen/logrus"
-	"github.com/urfave/cli"
+    vaultcli "github.com/hashicorp/vault/cli"
+    vaultcommand "github.com/hashicorp/vault/command"
+    "github.com/hashicorp/vault/physical"
+    log "github.com/mgutz/logxi/v1"
+    "github.com/robfig/cron"
+    "github.com/sirupsen/logrus"
+    "github.com/urfave/cli"
     "sync"
 )
 
 var backendFactories map[string]physical.Factory
 
 func init() {
-	// fish the backend factories out of the vault CLI, since that is inexplicably where
-	// this map is assembled
-	vaultCommands := vaultcli.Commands(nil)
-	cmd, err := vaultCommands["server"]()
-	if err != nil {
-		logrus.Fatal("'vault server' init failed", err)
-	}
-	serverCommand, ok := cmd.(*vaultcommand.ServerCommand)
-	if !ok {
-		logrus.Fatal("'vault server' did not return a ServerCommand")
-	}
-	backendFactories = serverCommand.PhysicalBackends
+    // fish the backend factories out of the vault CLI, since that is inexplicably where
+    // this map is assembled
+    vaultCommands := vaultcli.Commands(nil)
+    cmd, err := vaultCommands["server"]()
+    if err != nil {
+        logrus.Fatal("'vault server' init failed", err)
+    }
+    serverCommand, ok := cmd.(*vaultcommand.ServerCommand)
+    if !ok {
+        logrus.Fatal("'vault server' did not return a ServerCommand")
+    }
+    backendFactories = serverCommand.PhysicalBackends
 }
 
 func newBackend(kind string, logger log.Logger, conf map[string]string) (physical.Backend, error) {
-	if factory := backendFactories[kind]; factory == nil {
-		return nil, fmt.Errorf("no Vault backend is named %+q", kind)
-	} else {
-		return factory(conf, logger)
-	}
+    if factory := backendFactories[kind]; factory == nil {
+        return nil, fmt.Errorf("no Vault backend is named %+q", kind)
+    } else {
+        return factory(conf, logger)
+    }
 }
 
 //Backend is a supported storage backend by vault
 type Backend struct {
-	//Use the same name that is used in the vault config file
-	Name string `json:"name"`
-	//Put here the configuration of your picked backend
-	Config map[string]string `json:"config"`
+    //Use the same name that is used in the vault config file
+    Name string `json:"name"`
+    //Put here the configuration of your picked backend
+    Config map[string]string `json:"config"`
 }
 
 //Config config.json structure
 type Config struct {
-	//Source Backend
-	From *Backend `json:"from"`
-	//Destination Backend
-	To *Backend `json:"to"`
-	//Schedule (optional)
-	Schedule *string `json:"schedule"`
+    //Source Backend
+    From *Backend `json:"from"`
+    //Destination Backend
+    To *Backend `json:"to"`
+    //Schedule (optional)
+    Schedule *string `json:"schedule"`
     //Queue Size (optional)
     QueueSize int `json:"queuesize"`
     //Number of Workers (optional)
@@ -68,23 +68,23 @@ type Config struct {
 // Recurse through 'from' backend and add keys to a queue for processing by worker processes
 func populateKeyQueue(path string, from physical.Backend, keyQueue chan string) error {
     logrus.Infoln("listing keys : ", path)
-	keys, err := from.List(path)
-	if err != nil {
-		return err
-	}
-	for _, key := range keys {
-		if strings.HasSuffix(key, "/") {
+    keys, err := from.List(path)
+    if err != nil {
+        return err
+    }
+    for _, key := range keys {
+        if strings.HasSuffix(key, "/") {
             logrus.Infoln(": ", path+key)
-			err := populateKeyQueue(path+key, from, keyQueue)
-			if err != nil {
-				return err
-			}
-			continue
-		}
+            err := populateKeyQueue(path+key, from, keyQueue)
+            if err != nil {
+                return err
+            }
+            continue
+        }
         logrus.Infoln("adding key to queue: ", path+key)
-        keyQueue <- path+key
-	}
-	return nil
+        keyQueue <- path + key
+    }
+    return nil
 }
 
 // Retrieve keys from the queue until the channel is closed
@@ -122,16 +122,16 @@ func moveKey(key string, from physical.Backend, to physical.Backend) error {
 }
 
 func move(config *Config) error {
-	logger := log.New("vault-migrator")
+    logger := log.New("vault-migrator")
     var keyQueue = make(chan string, config.QueueSize)
-	from, err := newBackend(config.From.Name, logger, config.From.Config, )
-	if err != nil {
-		return err
-	}
-	to, err := newBackend(config.To.Name, logger, config.To.Config)
-	if err != nil {
-		return err
-	}
+    from, err := newBackend(config.From.Name, logger, config.From.Config, )
+    if err != nil {
+        return err
+    }
+    to, err := newBackend(config.To.Name, logger, config.To.Config)
+    if err != nil {
+        return err
+    }
     logrus.Infoln("Starting ", config.Workers, " workers...")
     var workerWaitGroup sync.WaitGroup
     workerWaitGroup.Add(config.Workers)
@@ -149,35 +149,35 @@ func move(config *Config) error {
 }
 
 func main() {
-	app := cli.NewApp()
-	app.Name = "vault-migrator"
-	app.Usage = ""
-	app.Version = version
-	app.Authors = []cli.Author{{"nebtex", "publicdev@nebtex.com"}}
-	app.Flags = []cli.Flag{cli.StringFlag{
-		Name:   "config, c",
-		Value:  "",
-		Usage:  "config file",
-		EnvVar: "VAULT_MIGRATOR_CONFIG_FILE",
-	}}
+    app := cli.NewApp()
+    app.Name = "vault-migrator"
+    app.Usage = ""
+    app.Version = version
+    app.Authors = []cli.Author{{"nebtex", "publicdev@nebtex.com"}}
+    app.Flags = []cli.Flag{cli.StringFlag{
+        Name:   "config, c",
+        Value:  "",
+        Usage:  "config file",
+        EnvVar: "VAULT_MIGRATOR_CONFIG_FILE",
+    }}
 
-	app.Action = func(c *cli.Context) error {
-		configFile := c.String("config")
-		configRaw, err := ioutil.ReadFile(configFile)
-		if err != nil {
-			return err
-		}
-		config := &Config{}
-		err = json.Unmarshal(configRaw, config)
-		if err != nil {
-			return err
-		}
-		if config.From == nil {
-			return fmt.Errorf("%v", "Please define a source (key: from)")
-		}
-		if config.To == nil {
-			return fmt.Errorf("%v", "Please define a destination (key: to)")
-		}
+    app.Action = func(c *cli.Context) error {
+        configFile := c.String("config")
+        configRaw, err := ioutil.ReadFile(configFile)
+        if err != nil {
+            return err
+        }
+        config := &Config{}
+        err = json.Unmarshal(configRaw, config)
+        if err != nil {
+            return err
+        }
+        if config.From == nil {
+            return fmt.Errorf("%v", "Please define a source (key: from)")
+        }
+        if config.To == nil {
+            return fmt.Errorf("%v", "Please define a destination (key: to)")
+        }
         if config.QueueSize <= 0 {
             // Default queue size to 10000
             config.QueueSize = 10000
@@ -188,39 +188,39 @@ func main() {
         }
 
         if config.Schedule == nil {
-			return move(config)
-		}
-		cr := cron.New()
-		err = cr.AddFunc(*config.Schedule, func() {
-			defer func() {
-				err := recover()
-				if err != nil {
-					logrus.Errorln(err)
-				}
-			}()
-			err = move(config)
-			if err != nil {
-				logrus.Errorln(err)
-			}
-		})
-		if err != nil {
-			return err
-		}
-		cr.Start()
-		//make initial migration
-		err = move(config)
-		if err != nil {
-			return err
-		}
-		for {
-			time.Sleep(time.Second * 60)
-			logrus.Info("Waiting the next schedule")
+            return move(config)
+        }
+        cr := cron.New()
+        err = cr.AddFunc(*config.Schedule, func() {
+            defer func() {
+                err := recover()
+                if err != nil {
+                    logrus.Errorln(err)
+                }
+            }()
+            err = move(config)
+            if err != nil {
+                logrus.Errorln(err)
+            }
+        })
+        if err != nil {
+            return err
+        }
+        cr.Start()
+        //make initial migration
+        err = move(config)
+        if err != nil {
+            return err
+        }
+        for {
+            time.Sleep(time.Second * 60)
+            logrus.Info("Waiting the next schedule")
 
-		}
+        }
 
-	}
-	err := app.Run(os.Args)
-	if err != nil {
-		logrus.Fatal(err)
-	}
+    }
+    err := app.Run(os.Args)
+    if err != nil {
+        logrus.Fatal(err)
+    }
 }


### PR DESCRIPTION
- List operation adds keys to a queue
- Workers retrieve key from queue and copy the key from the source to the destination backend
- Queue Size configuration added (defaults to 10000)
- Workers configuration added (defaults to 100)